### PR TITLE
Remove onOpen console.info

### DIFF
--- a/src/ResilientWebSocket.ts
+++ b/src/ResilientWebSocket.ts
@@ -120,7 +120,6 @@ class ResilientWebSocket {
     };
 
     private onOpen = () => {
-        console.info('onOpen');
         this.respondToCallbacks(WebSocketEvent.CONNECTION, this);
 
         if (this.options.pingEnabled) {


### PR DESCRIPTION
hiya! I really like resilient-websocket -- I normally like my consoles to run clean, so it took me a little bit to find where this console was happening.

Are you OK with removing this console.info? I feel like if I wanted to include this, I would have it be in my `socket.on(WebSocketEvent.CONNECTION` event.